### PR TITLE
trying to debug ongoing performance issues.

### DIFF
--- a/Expungement-Generator/CPCMS.php
+++ b/Expungement-Generator/CPCMS.php
@@ -405,7 +405,7 @@ print "
             $summary = new ArrestSummary();
             $summary->readArrestSummary($thisRecord);
             $sArrests = $summary->getArrests();
-
+            $dnQueue = array(); // array for tracking dockets we need.
             // compare the arrests from the summary docket to the
             // arrests already on this CPCMS object.  Add in any arrests
             // that weren't already there with a notation that they were found on the summary
@@ -431,7 +431,8 @@ print "
                     // if we never found a match, add this docket number to
                     // the list of results.
                     // false indicates that this is a CP, not MDJ docket.
-                    $this->results[] = $docketNumberSearch($dn, false)["docket"];
+                    $dnQueue[] = $dn;
+                    // $this->results[] = docketNumberSearch($dn, false)["docket"];
 
                       // replaced by a function to add a single docket to the
                       // the results array
@@ -441,6 +442,10 @@ print "
                       // );
                 }// end loop through dockets associated w/ an arrest
             }// end loop through list of arrests found in a summary docket
+            $results = manyDocketNumberSearch($dnQueue, false);
+            $this->results = array_merge(
+                $this->results,
+                $results["dockets"]);
         }
     }
 

--- a/Expungement-Generator/CPCMS.php
+++ b/Expungement-Generator/CPCMS.php
@@ -431,7 +431,7 @@ print "
                     // if we never found a match, add this docket number to
                     // the list of results.
                     // false indicates that this is a CP, not MDJ docket.
-                    $this->results[] = docketNumberSearch($dn, false)["docket"];
+                    $this->results[] = $docketNumberSearch($dn, false)["docket"];
 
                       // replaced by a function to add a single docket to the
                       // the results array

--- a/Expungement-Generator/helpers/docketsearch_api.php
+++ b/Expungement-Generator/helpers/docketsearch_api.php
@@ -50,6 +50,34 @@ function docketNameSearch($firstName, $lastName, $dob, $mdj) {
   return $jsonResults;
 }
 
+
+function manyDocketNumberSearch($dnQueue, $mdj) {
+  error_log("Searching for " . count($dnQueue) . " docket numbers at once.");
+  global $docketScraperAPIURL;
+  $ch = curl_init($docketScraperAPIURL . "/" . "lookupMultipleDockets");
+  $jsonData = array(
+    "docket_numbers" => $dnQueue
+  );
+  $jsonDataEncoded = json_encode($jsonData);
+  //Tell cURL that we want to send a POST request.
+  curl_setopt($ch, CURLOPT_POST, 1);
+  //Attach our encoded JSON string to the POST fields.
+  curl_setopt($ch, CURLOPT_POSTFIELDS, $jsonDataEncoded);
+  //Set the content type to application/json
+  curl_setopt(
+      $ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+  //Do not print request results.
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+  curl_setopt($ch, CURLOPT_VERBOSE, 0);
+  $result = curl_exec($ch);
+  error_log("Completed searching for " . count($dnQueue) . " docket numbers at once.");
+  curl_close($ch);
+  $jsonResults = json_decode($result, true);
+  error_log("Found " . count($jsonResults["dockets"]) . " of " . count($dnQueue) . " .");
+  return $jsonResults;
+}
+
+
 // Use the docket scraper api to search for a specific docket.
 //
 // Args:


### PR DESCRIPTION
 My idea now is to have the api's lookup accept a list of docket numbers, so that we can queue a bunch of dockets to look up at a time. This way at least, the overhead of starting and stopping a browser will be reduced.

First, the api app will need to support a docket lookup for multiple dockets.

Second, the EG (and this is what this branch is for) should be modified in the following way.

In CPCMS.php, in the integrateSummaryInformation function, instead of direclty adding dockets to `results[]`, create a list of the docket numbers that are found in the Summary, but not already known. Then call the api with that list. The api will return a json object with a key `dockets` that should be added to the `results[]` array in cpcms.